### PR TITLE
Algorithms | Arrays - two sum

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1006,6 +1006,7 @@
       * [Is Triangle Test](https://github.com/BrianLusina/gopher-land/blob/master/gomath/triangle/istriangle/is_triangle_test.go)
   * Twosum
     * [Twosum](https://github.com/BrianLusina/gopher-land/blob/master/gomath/twosum/twosum.go)
+    * [Twosum Test](https://github.com/BrianLusina/gopher-land/blob/master/gomath/twosum/twosum_test.go)
   * Utils
     * [Reverseint](https://github.com/BrianLusina/gopher-land/blob/master/gomath/utils/reverseint.go)
     * [Reverseint Test](https://github.com/BrianLusina/gopher-land/blob/master/gomath/utils/reverseint_test.go)

--- a/gomath/twosum/README.md
+++ b/gomath/twosum/README.md
@@ -5,3 +5,48 @@ Write a function that takes an array of numbers (integers for the tests) and a t
 The input will always be valid (numbers will be an array of length 2 or greater, and all of the items will be numbers; target will always be the sum of two different items from that array).
 
 twoSum [1, 2, 3] 4 === (0, 2)
+
+---
+
+## Two Sum - Input Array Is Sorted
+
+Given a 1-indexed array of integers numbers that is already sorted in non-decreasing order, find two numbers such that
+they add up to a specific target number. Let these two numbers be numbers[index1] and numbers[index2] where 1 <=
+index1 < index2 <= numbers.length.
+
+Return the indices of the two numbers, index1 and index2, added by one as an integer array [index1, index2] of length 2.
+
+The tests are generated such that there is exactly one solution. You may not use the same element twice.
+
+Your solution must use only constant extra space.
+
+```text
+
+Example 1:
+
+Input: numbers = [2,7,11,15], target = 9
+Output: [1,2]
+Explanation: The sum of 2 and 7 is 9. Therefore, index1 = 1, index2 = 2. We return [1, 2].
+```
+
+```text
+Example 2:
+
+Input: numbers = [2,3,4], target = 6
+Output: [1,3]
+Explanation: The sum of 2 and 4 is 6. Therefore index1 = 1, index2 = 3. We return [1, 3].
+```
+
+```text
+Example 3:
+
+Input: numbers = [-1,0], target = -1
+Output: [1,2]
+Explanation: The sum of -1 and 0 is -1. Therefore index1 = 1, index2 = 2. We return [1, 2].
+```
+
+## Related Topics
+
+- Array
+- Two Pointers
+- Binary Search

--- a/gomath/twosum/twosum.go
+++ b/gomath/twosum/twosum.go
@@ -18,3 +18,25 @@ func TwoSum(numbers []int, target int) [2]int {
 	}
 	return [2]int{0, 0}
 }
+
+// twoSumII finds the indices of two integers from a 1-index based numbers slice sorted in increasing order that add up to a target
+// This uses a binary search to find the two numbers that add up to the target with the left and right pointer at both ends of thes lice
+// Space complexity is O(2) where we store 2 numbers in the return result, and Time complexity is O(n log(n)) as a binary search algorithm
+// is used to find the two numbers
+func twoSumII(numbers []int, target int) [2]int {
+	left, right := 0, len(numbers)-1
+
+	for left < right {
+		sum := numbers[left] + numbers[right]
+
+		if sum > target {
+			right--
+		} else if sum < target {
+			left++
+		} else {
+			return [2]int{left + 1, right + 1}
+		}
+	}
+
+	return [2]int{0, 0}
+}

--- a/gomath/twosum/twosum_test.go
+++ b/gomath/twosum/twosum_test.go
@@ -1,0 +1,53 @@
+package twosum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	numbers  []int
+	target   int
+	expected [2]int
+}
+
+var testCases = []testCase{
+	{
+		numbers:  []int{2, 7, 11, 15},
+		target:   9,
+		expected: [2]int{1, 2},
+	},
+	{
+		numbers:  []int{2, 3, 4},
+		target:   6,
+		expected: [2]int{1, 3},
+	},
+	{
+		numbers:  []int{-1, 0},
+		target:   -1,
+		expected: [2]int{1, 2},
+	},
+}
+
+func TestTwoSumII(t *testing.T) {
+	for _, tc := range testCases {
+		if actual := twoSumII(tc.numbers, tc.target); !assert.ElementsMatch(t, actual, tc.expected) {
+			t.Fatalf("twoSumII(%v, %d)=%v, expected=%v", tc.numbers, tc.target, actual, tc.expected)
+		}
+	}
+}
+
+func BenchmarkTwoSumII(b *testing.B) {
+	if testing.Short() {
+		b.Skip()
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			if actual := twoSumII(tc.numbers, tc.target); !assert.ElementsMatch(b, actual, tc.expected) {
+				b.Fatalf("twoSumII(%v, %d)=%v, expected=%v", tc.numbers, tc.target, actual, tc.expected)
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Two Sum

Given a 1-indexed array of integers numbers that is already sorted in non-decreasing order, find two numbers such that
they add up to a specific target number. Let these two numbers be numbers[index1] and numbers[index2] where 1 <=
index1 < index2 <= numbers.length.

* [x] Add an algorithm?
* [x] Documentation change?

## **Checklist:**

* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Go files are placed inside an existing directory.
* [x] All functions and variable names follow Go naming conventions.